### PR TITLE
Better brew caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ jobs:
         # Cache all other dependencies and data
         - save_cache:
             paths:
-              - ~/circleci/repo/data
-              - ~/circleci/.linuxbrew
+              - ~/repo/data
+              - ~/.linuxbrew
             key: v1-general-dependencies-{{ checksum "base_installation.sh" }}
 
         # Run the end-to-end test

--- a/base_installation.sh
+++ b/base_installation.sh
@@ -35,26 +35,24 @@ if [ ! `which ktImportText` ] ; then
   cd $metAnnotateDir
 fi
 
+
 # The two possible paths to linuxbrew.
 BREW_PATH_ONE=~/.linuxbrew
 BREW_PATH_TWO=/home/linuxbrew/.linuxbrew
 
+echo -e "\nInstalling Linuxbrew\n"
+if [ ! -d "$BREW_PATH_ONE" ] && [ ! -d "$BREW_PATH_TWO" ] ; then
+    yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
+fi
 
-#echo -e "\nInstalling Linuxbrew\n"
-#if [ ! -d "$BREW_PATH_ONE" ] && [ ! -d "$BREW_PATH_TWO" ] ; then
-#    yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
-#fi
-#
-#echo -e "\nAttempting to add Brew to PATH\n"
-#if [ ! `which brew` ] ; then
-#    echo -e "\nAdding Brew to PATH\n"
-#    test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
-#    test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-#    test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile
-#    echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.profile
-#fi
-
-exit 1
+echo -e "\nAttempting to add Brew to PATH\n"
+if [ ! `which brew` ] ; then
+    echo -e "\nAdding Brew to PATH\n"
+    test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
+    test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+    test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile
+    echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.profile
+fi
 
 brew tap homebrew/science
 brew install emboss --without-x

--- a/base_installation.sh
+++ b/base_installation.sh
@@ -39,19 +39,22 @@ fi
 BREW_PATH_ONE=~/.linuxbrew
 BREW_PATH_TWO=/home/linuxbrew/.linuxbrew
 
-echo -e "\nInstalling Linuxbrew\n"
-if [ ! -d "$BREW_PATH_ONE" ] && [ ! -d "$BREW_PATH_TWO" ] ; then
-    yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
-fi
 
-echo -e "\nAttempting to add Brew to PATH\n"
-if [ ! `which brew` ] ; then
-    echo -e "\nAdding Brew to PATH\n"
-    test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
-    test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-    test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile
-    echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.profile
-fi
+#echo -e "\nInstalling Linuxbrew\n"
+#if [ ! -d "$BREW_PATH_ONE" ] && [ ! -d "$BREW_PATH_TWO" ] ; then
+#    yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
+#fi
+#
+#echo -e "\nAttempting to add Brew to PATH\n"
+#if [ ! `which brew` ] ; then
+#    echo -e "\nAdding Brew to PATH\n"
+#    test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
+#    test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+#    test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile
+#    echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.profile
+#fi
+
+exit 1
 
 brew tap homebrew/science
 brew install emboss --without-x

--- a/base_installation.sh
+++ b/base_installation.sh
@@ -35,13 +35,18 @@ if [ ! `which ktImportText` ] ; then
   cd $metAnnotateDir
 fi
 
+# The two possible paths to linuxbrew.
+BREW_PATH_ONE=~/.linuxbrew
+BREW_PATH_TWO=/home/linuxbrew/.linuxbrew
+
 echo -e "\nInstalling Linuxbrew\n"
-if [ ! -d "/home/linuxbrew/.linuxbrew" ] && [ ! -d "~/.linuxbrew" ] ; then
+if [ ! -d "$BREW_PATH_ONE" ] && [ ! -d "$BREW_PATH_TWO" ] ; then
     yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
 fi
 
-echo -e "\nAdding Brew to PATH\n"
+echo -e "\nAttempting to add Brew to PATH\n"
 if [ ! `which brew` ] ; then
+    echo -e "\nAdding Brew to PATH\n"
     test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
     test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
     test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile

--- a/base_installation.sh
+++ b/base_installation.sh
@@ -36,11 +36,16 @@ if [ ! `which ktImportText` ] ; then
 fi
 
 echo -e "\nInstalling Linuxbrew\n"
-if [ ! `which brew` ] ; then
+if [ ! -d "/home/linuxbrew/.linuxbrew" ] && [ ! -d "~/.linuxbrew" ] ; then
     yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/linuxbrew/go/install)"
-    PATH="$HOME/.linuxbrew/bin:$PATH"
-    export MANPATH="$(brew --prefix)/share/man:$MANPATH"
-    export INFOPATH="$(brew --prefix)/share/info:$INFOPATH"
+fi
+
+echo -e "\nAdding Brew to PATH\n"
+if [ ! `which brew` ] ; then
+    test -d ~/.linuxbrew && PATH="$HOME/.linuxbrew/bin:$PATH"
+    test -d /home/linuxbrew/.linuxbrew && PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+    test -r ~/.bash_profile && echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.bash_profile
+    echo 'export PATH="$(brew --prefix)/bin:$PATH"' >>~/.profile
 fi
 
 brew tap homebrew/science


### PR DESCRIPTION
- Replaced ```~/circleci/repo/data``` with  ```~/repo/data``` during caching phase. ```~/circleci/repo/data``` is actually tilde expanded to ```/home/circleci/circleci/repo/data``` which is a non existent directory. Thus we were not caching anything 💃 .

- Brew portion of the install has been split into two parts. One for checking if brew is mechanically installed and another for checking if the ```brew``` command can be actually be called. 