### PR TITLE
Zenodo databases

### DIFF
--- a/base_installation.sh
+++ b/base_installation.sh
@@ -87,9 +87,9 @@ fi
 echo -e "\nDownloading and indexing gi number to taxid mappings.\n"
 if [ ! -e data/gi_taxid_prot.dmp ] ; then
   cd precompute
-  wget "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/gi_taxid_prot.dmp.gz"
-  gunzip gi_taxid_prot.dmp.gz
-  mv gi_taxid_prot.dmp ../data/
+  wget "https://zenodo.org/record/1098450/files/gi_taxid_prot_2017_03_01.dmp.bz2"
+  pbzip2 -d gi_taxid_prot_2017_03_01.dmp.bz2
+  mv gi_taxid_prot_2017_03_01.dmp ../data/gi_taxid_prot.dmp
   cd ${metAnnotateDir}
 else
   echo -e "\nTaxid mappings already cached.\n"

--- a/base_installation.sh
+++ b/base_installation.sh
@@ -72,10 +72,13 @@ fi
 echo -e "\nDownloading and indexing taxonomy info.\n"
 if [ ! -e data/taxonomy.pickle ] ; then
   cd precompute
-  wget "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz"
-  tar -zxf taxdump.tar.gz
+  wget "https://zenodo.org/record/1098450/files/taxdump_2017_03_01.tar.bz2"
+  tar -jxf taxdump_2017_03_01.tar.bz2
   grep 'scientific name' names.dmp > trimmed.names.dmp
   python make_taxonomy_pickle.py
+  rm -f precompute/gc.prt
+  rm -f precompute/readme.txt
+  rm -f precompute/taxdump_2017_03_01.tar.bz2
   cd ${metAnnotateDir}
 else
     echo -e "\nRefseq taxonomy dump already cached.\n"
@@ -103,9 +106,6 @@ crontab mycron
 rm mycron
 
 rm -rf downloads
-rm -f precompute/gc.prt
-rm -f precompute/readme.txt
-rm -f precompute/taxdump.tar.gz
 
 echo "$HOME/.local/bin/" > path.txt
 

--- a/one_command_install.sh
+++ b/one_command_install.sh
@@ -20,7 +20,9 @@ echo "Checking Refseq database being downloaded"
 #This might take a few hours
 if [ ! -e "Refseq.fa" ] || [ ! -e "Refseq.fa.ssi" ]; then
     echo "Downloading RefSeq database; could take a few hours if connection is slow"
-    # Note: when downloading from NCBI instead of Zenodo, this may have downloaded several files and then combined them. Keep this in mind if moving back to downloading directly from NCBI.
+    # Note: the old code that was here for downloading RefSeq directly from NCBI (instead of from Zenodo) implied that
+    # multiple files were downloaded from NCBI and then combined during a preprocessing step. Watch for this when
+    # updating this code to pull directly from NCBI again instead of from Zenodo; some modifications may be needed.
     wget "https://zenodo.org/record/1098450/files/metannotate_refseq_db_w_gi_2017_03_01.fa.bz2"
     pbzip2 -d -c metannotate_refseq_db_w_gi_2017_03_01.fa.bz2 > Refseq.fa
     echo "Preprocessing Refseq.fa to removing uncommon amino acids"

--- a/one_command_install.sh
+++ b/one_command_install.sh
@@ -19,17 +19,18 @@ cd ${metAnnotateDir}/data
 echo "Checking Refseq database being downloaded"
 #This might take a few hours
 if [ ! -e "Refseq.fa" ] || [ ! -e "Refseq.fa.ssi" ]; then
-    echo "downloading refseq db, will take a few hours"
-    wget ftp://ftp.ncbi.nlm.nih.gov/refseq/release/complete/complete.nonredundant_protein*.protein.faa.gz
-    zcat *.faa.gz >Refseq.fa
-    echo "preprocessing Refseq.fa, removing uncommon amino acids"
+    echo "Downloading RefSeq database; could take a few hours if connection is slow"
+    # Note: when downloading from NCBI instead of Zenodo, this may have downloaded several files and then combined them. Keep this in mind if moving back to downloading directly from NCBI.
+    wget "https://zenodo.org/record/1098450/files/metannotate_refseq_db_w_gi_2017_03_01.fa.bz2"
+    pbzip2 -d -c metannotate_refseq_db_w_gi_2017_03_01.fa.bz2 > Refseq.fa
+    echo "Preprocessing Refseq.fa to removing uncommon amino acids"
     perl ../scripts/cleanDatabase.pl Refseq.fa > list_to_remove.txt
     perl ../scripts/removeFromFasta.pl list_to_remove.txt Refseq.fa > Refseq.fixed.fa
     rm list_to_remove.txt
     rm Refseq.fa
     mv Refseq.fixed.fa Refseq.fa
-    echo "preprocessing completes"
-    rm *.faa.gz
+    echo "Preprocessing completes"
+    rm metannotate_refseq_db_w_gi_2017_03_01.fa.bz2
     ~/.local/bin/esl-sfetch --index Refseq.fa
 fi
 


### PR DESCRIPTION
Modified ```base_installation.sh``` to download database information from a [custom Zenodo repository](http://doi.org/10.5281/zenodo.1098450) instead of directly from NCBI. RefSeq release 80 is used, from March 2017, before NCBI eliminated GI numbers. This is a temporary workaround until MetAnnotate code is able to support GI number-less NCBI databases.